### PR TITLE
Allow converting Set to DiscreteSpace

### DIFF
--- a/src/implementations/spaces/discrete_space.jl
+++ b/src/implementations/spaces/discrete_space.jl
@@ -20,7 +20,7 @@ Random.rand(rng::AbstractRNG, s::DiscreteSpace) = rand(rng, s.span)
 
 Base.length(s::DiscreteSpace) = length(s.span)
 
-Base.convert(::Type{AbstractSpace}, s::Union{<:Integer,<:UnitRange,<:Vector,<:Tuple}) =
+Base.convert(::Type{AbstractSpace}, s::Union{<:Integer,<:UnitRange,<:Vector,<:Tuple, <:Set}) =
     DiscreteSpace(s)
 
 Base.iterate(s::DiscreteSpace, args...) = iterate(s.span, args...)


### PR DESCRIPTION
`Set` can also safely convert to a `DiscreteSpace`.

https://github.com/JuliaReinforcementLearning/ReinforcementLearningEnvironments.jl/issues/25