### PR TITLE
Simplify APIs

### DIFF
--- a/src/ReinforcementLearningBase.jl
+++ b/src/ReinforcementLearningBase.jl
@@ -6,5 +6,6 @@ export RLBase
 include("inline_export.jl")
 include("interface.jl")
 include("implementations/implementations.jl")
+include("base.jl")
 
 end # module

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,0 +1,23 @@
+Base.run(π, env::AbstractEnv) = run(π, env, DynamicStyle(env))
+
+function Base.run(π, env::AbstractEnv, ::Sequential)
+    obs = observe(env)
+    while !get_terminal(obs)
+        obs |> π |> env
+        obs = observe(env)
+    end
+end
+
+function Base.run(Π::Vector, env::AbstractEnv, ::Sequential)
+    is_terminal = false
+    while !is_terminal
+        for π in Π
+            obs = observe(env)
+            if get_terminal(obs)
+                is_terminal = true
+                break
+            end
+            obs |> π |> env
+        end
+    end
+end

--- a/src/implementations/environments.jl
+++ b/src/implementations/environments.jl
@@ -1,9 +1,49 @@
-export WrappedEnv, MultiThreadEnv
+export LotteryEnv, WrappedEnv, MultiThreadEnv
 
 using MacroTools: @forward
 using Random
 
 import Base.Threads.@spawn
+
+#####
+# LotteryEnv
+#####
+
+"""
+    LotteryEnv()
+
+Here we use an example introduced in [Monte Carlo Tree Search: A Tutorial](https://www.informs-sim.org/wsc18papers/includes/files/021.pdf) to demenstrate how to write an environment.
+
+Assume you have \$10 in your pocket, and you are faced with the following three choices:
+
+1. buy a PowerRich lottery ticket (win \$100M w.p. 0.01; nothing otherwise);
+2. buy a MegaHaul lottery ticket (win \$1M w.p. 0.05; nothing otherwise);
+3. do not buy a lottery ticket.
+"""
+mutable struct LotteryEnv <: AbstractEnv
+    reward::Int
+    is_done::Bool
+    rng::MersenneTwister
+end
+
+LotteryEnv(;seed=nothing) = LotteryEnv(0, false, MersenneTwister(seed))
+
+get_action_space(env::LotteryEnv) = DiscreteSpace((:PowerRich, :MegaHaul, nothing))
+
+function (env::LotteryEnv)(action::Union{Symbol,Nothing})
+    if action == :PowerRich
+        env.reward = rand(env.rng) < 0.01 ? 100_000_000 : -10
+    elseif action == :MegaHaul
+        env.reward = rand(env.rng) < 0.05 ? 1_000_000 : -10
+    else
+        env.reward = 0
+    end
+    env.is_done = true
+end
+
+observe(env::LotteryEnv) = (reward=env.reward, terminal=env.is_done)
+
+reset!(env::LotteryEnv) = env.is_done = false
 
 #####
 # WrappedEnv
@@ -15,23 +55,33 @@ import Base.Threads.@spawn
 The observation of the inner `env` is first transformed by the `preprocessor`.
 And the action is transformed by `postprocessor` and then send to the inner `env`.
 """
-Base.@kwdef struct WrappedEnv{P<:AbstractPreprocessor,E<:AbstractEnv,T} <: AbstractEnv
+Base.@kwdef struct WrappedEnv{P,E<:AbstractEnv,T} <: AbstractEnv
     preprocessor::P
     env::E
     postprocessor::T = identity
 end
 
+"TODO: Deprecate"
 WrappedEnv(p, env) = WrappedEnv(preprocessor = p, env = env)
 
 (env::WrappedEnv)(args...) = env.env(env.postprocessor(args)...)
 
 @forward WrappedEnv.env DynamicStyle,
-get_current_player,
+ChanceStyle,
+InformationStyle,
+RewardStyle,
+UtilityStyle,
+ActionStyle,
 get_action_space,
 get_observation_space,
+get_current_player,
+get_player_id,
+get_num_players,
+get_history,
 render,
 reset!,
-Random.seed!
+Random.seed!,
+Base.copy
 
 observe(env::WrappedEnv, player) = env.preprocessor(observe(env.env, player))
 observe(env::WrappedEnv) = env.preprocessor(observe(env.env))
@@ -52,8 +102,6 @@ struct MultiThreadEnv{O,E} <: AbstractEnv
 end
 
 MultiThreadEnv(envs) = MultiThreadEnv(BatchObs([observe(env) for env in envs]), envs)
-
-@forward MultiThreadEnv.envs Base.getindex, Base.length, Base.setindex!
 
 RLBase.get_action_space(env::MultiThreadEnv) = get_action_space(env.envs[1])
 RLBase.get_observation_space(env::MultiThreadEnv) = get_observation_space(env.envs[1])
@@ -85,3 +133,7 @@ function RLBase.reset!(env::MultiThreadEnv; is_force = false)
         end
     end
 end
+
+@forward MultiThreadEnv.envs Base.getindex, Base.length, Base.setindex!
+
+# TODO general APIs for MultiThreadEnv are missing

--- a/src/implementations/environments.jl
+++ b/src/implementations/environments.jl
@@ -1,5 +1,4 @@
-export LotteryEnv,
-    WrappedEnv,
+export WrappedEnv,
     MultiThreadEnv,
     AbstractPreprocessor,
     CloneStatePreprocessor,
@@ -9,46 +8,6 @@ using MacroTools: @forward
 using Random
 
 import Base.Threads.@spawn
-
-#####
-# LotteryEnv
-#####
-
-"""
-    LotteryEnv()
-
-Here we use an example introduced in [Monte Carlo Tree Search: A Tutorial](https://www.informs-sim.org/wsc18papers/includes/files/021.pdf) to demenstrate how to write an environment.
-
-Assume you have \$10 in your pocket, and you are faced with the following three choices:
-
-1. buy a PowerRich lottery ticket (win \$100M w.p. 0.01; nothing otherwise);
-2. buy a MegaHaul lottery ticket (win \$1M w.p. 0.05; nothing otherwise);
-3. do not buy a lottery ticket.
-"""
-mutable struct LotteryEnv <: AbstractEnv
-    reward::Int
-    is_done::Bool
-    rng::MersenneTwister
-end
-
-LotteryEnv(;seed=nothing) = LotteryEnv(0, false, MersenneTwister(seed))
-
-get_action_space(env::LotteryEnv) = DiscreteSpace((:PowerRich, :MegaHaul, nothing))
-
-function (env::LotteryEnv)(action::Union{Symbol,Nothing})
-    if action == :PowerRich
-        env.reward = rand(env.rng) < 0.01 ? 100_000_000 : -10
-    elseif action == :MegaHaul
-        env.reward = rand(env.rng) < 0.05 ? 1_000_000 : -10
-    else
-        env.reward = 0
-    end
-    env.is_done = true
-end
-
-observe(env::LotteryEnv) = (reward=env.reward, terminal=env.is_done)
-
-reset!(env::LotteryEnv) = env.is_done = false
 
 #####
 # WrappedEnv

--- a/src/implementations/implementations.jl
+++ b/src/implementations/implementations.jl
@@ -1,3 +1,4 @@
 include("spaces/spaces.jl")
 include("observations.jl")
 include("environments.jl")
+include("policies.jl")

--- a/src/implementations/policies.jl
+++ b/src/implementations/policies.jl
@@ -45,6 +45,9 @@ end
 
 get_prob(p::RandomPolicy, obs) = get_prob(p, obs, ActionStyle(obs))
 
+# TODO: TBD
+# Ideally we should return a Categorical distribution.
+# But this means we need to introduce an extra dependency of Distributions
 get_prob(p::RandomPolicy, obs, ::MinimalActionSet) = fill(1 / length(p.action_space), length(p.action_space))
 
 function get_prob(p::RandomPolicy, obs, ::FullActionSet)

--- a/src/implementations/policies.jl
+++ b/src/implementations/policies.jl
@@ -31,7 +31,12 @@ RandomPolicy(env::AbstractEnv; seed = nothing) =
 
 function (p::RandomPolicy)(obs, ::FullActionSet)
     legal_actions = get_legal_actions(obs)
-    length(legal_actions) == 0 ? get_invalid_action(obs) : rand(p.rng, legal_actions)
+    if length(legal_actions) == 0
+        # in this case, we return an random action instead of throwing error
+        rand(p.rng, p.action_space)
+    else
+        rand(p.rng, legal_actions)
+    end
 end
 
 (p::RandomPolicy)(obs, ::MinimalActionSet) = rand(p.rng, p.action_space)

--- a/src/implementations/policies.jl
+++ b/src/implementations/policies.jl
@@ -1,0 +1,42 @@
+export RandomPolicy
+
+using Random
+
+"""
+    RandomPolicy(action_space, rng)
+
+Randomly return a valid action.
+"""
+struct RandomPolicy{S<:AbstractSpace,R<:AbstractRNG} <: AbstractPolicy
+    action_space::S
+    rng::R
+end
+
+Base.show(io::IO, p::RandomPolicy) = print(io, "RandomPolicy($(p.action_space))")
+
+Random.seed!(p::RandomPolicy, seed) = Random.seed!(p.rng, seed)
+
+"""
+    RandomPolicy(action_space; seed=nothing)
+"""
+RandomPolicy(s; seed = nothing) = RandomPolicy(s, MersenneTwister(seed))
+
+"""
+    RandomPolicy(env::AbstractEnv; seed=nothing)
+"""
+RandomPolicy(env::AbstractEnv; seed = nothing) =
+    RandomPolicy(get_action_space(env), MersenneTwister(seed))
+
+function (p::RandomPolicy)(obs, ::FullActionSet)
+    legal_actions = get_legal_actions(obs)
+    length(legal_actions) == 0 ? get_invalid_action(obs) : rand(p.rng, legal_actions)
+end
+
+(p::RandomPolicy)(obs, ::MinimalActionSet) = rand(p.rng, p.action_space)
+(p::RandomPolicy)(obs::BatchObs, ::MinimalActionSet) =
+    [rand(p.rng, p.action_space) for _ in 1:length(obs)]
+
+update!(p::RandomPolicy, experience) = nothing
+
+get_prob(p::RandomPolicy, s) = fill(1 / length(p.action_space), length(p.action_space))
+get_prob(p::RandomPolicy, s, a) = 1 / length(p.action_space)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -61,14 +61,14 @@ Usually used in offline policies.
 #####
 
 """
-    (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action) -> nothing
+    (env::AbstractEnv)(action) = env(get_current_player(env), action) -> nothing
     (env::AbstractEnv)(player, action) -> nothing
 
 Super type of all reinforcement learning environments.
 """
 @interface abstract type AbstractEnv end
 
-@interface (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action)
+@interface (env::AbstractEnv)(action) = env(get_current_player(env), action)
 @interface (env::AbstractEnv)(player, action)
 
 #####
@@ -189,12 +189,20 @@ abstract type AbstractActionStyle end
 @interface const MINIMAL_ACTION_SET = MinimalActionSet()
 
 """
+    ActionStyle(env::AbstractEnv)
     ActionStyle(obs)
 
 Specify whether the observation contains a full action set or a minimal action set.
 By default the [`MINIMAL_ACTION_SET`](@ref) is returned.
 """
 @interface ActionStyle(obs) = MINIMAL_ACTION_SET
+
+ActionStyle(obs::NamedTuple{(:reward, :terminal, :state, :legal_actions)}) = FULL_ACTION_SET
+ActionStyle(obs::NamedTuple{(:reward, :terminal, :state, :legal_actions_mask)}) =
+    FULL_ACTION_SET
+ActionStyle(
+    obs::NamedTuple{(:reward, :terminal, :state, :legal_actions, :legal_actions_mask)},
+) = FULL_ACTION_SET
 
 #####
 ## general
@@ -210,8 +218,7 @@ By default the [`MINIMAL_ACTION_SET`](@ref) is returned.
 """
 @interface get_observation_space(env::AbstractEnv) = env.observation_space
 
-"Return [`DEFAULT_PLAYER`](@ref) by default"
-@interface get_current_player(env::AbstractEnv) = DEFAULT_PLAYER
+@interface get_current_player(env::AbstractEnv)
 
 """
     get_player_id(player, env::AbstractEnv) -> Int

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -21,64 +21,150 @@ Julia. From the concept level, they can be organized in the following parts:
 using Random
 
 #####
-# general
+# Policy
 #####
 
 """
-In the simplest case, we just need to run `env |> observe |> agent |> env` repeatly. But usually we would also like to control when/how to update the agent. So we defined the following stages for the help:
+    (π::AbstractPolicy)(obs) -> action
 
-- `PRE_EXPERIMENT_STAGE`
-- `PRE_EPISODE_STAGE`
-- `PRE_ACT_STAGE`
-- `POST_ACT_STAGE`
-- `POST_EPISODE_STAGE`
-- `POST_EXPERIMENT_STAGE`
-
-```
-                      +-----------------------------------------------------------+                      
-                      |Episode                                                    |                      
-                      |                                                           |                      
-PRE_EXPERIMENT_STAGE  |            PRE_ACT_STAGE    POST_ACT_STAGE                | POST_EXPERIMENT_STAGE
-         |            |                  |                |                       |          |           
-         v            |        +-----+   v   +-------+    v   +-----+             |          v           
-         --------------------->+ env +------>+ agent +------->+ env +---> ... ------->......             
-                      |  ^     +-----+  obs  +-------+ action +-----+          ^  |                      
-                      |  |                                                     |  |                      
-                      |  +--PRE_EPISODE_STAGE            POST_EPISODE_STAGE----+  |                      
-                      |                                                           |                      
-                      |                                                           |                      
-                      +-----------------------------------------------------------+                      
-```
+Policy is the most basic concept in reinforcement learning. A policy is a functional object which takes in an observation and generate an action.
 """
-@interface abstract type AbstractStage end
+@interface abstract type AbstractPolicy end
+@interface (π::AbstractPolicy)(obs)
 
-@interface struct PreExperimentStage <: AbstractStage end
-@interface struct PostExperimentStage <: AbstractStage end
-@interface struct PreEpisodeStage <: AbstractStage end
-@interface struct PostEpisodeStage <: AbstractStage end
-@interface struct PreActStage <: AbstractStage end
-@interface struct PostActStage <: AbstractStage end
-
-@interface const PRE_EXPERIMENT_STAGE = PreExperimentStage()
-@interface const POST_EXPERIMENT_STAGE = PostExperimentStage()
-@interface const PRE_EPISODE_STAGE = PreEpisodeStage()
-@interface const POST_EPISODE_STAGE = PostEpisodeStage()
-@interface const PRE_ACT_STAGE = PreActStage()
-@interface const POST_ACT_STAGE = PostActStage()
 
 """
-The default value of invalid action for all the environments.
-However, one can still specify the value for a specific environment
-or observation.
+    update!(π::AbstractPolicy, experience)
 
-# See also: [`get_invalid_action`](@ref)
+Update the policy `π` with online/offline experience.
 """
-@interface const INVALID_ACTION = 0
+@interface update!(π::AbstractPolicy, experience) = nothing
 
-struct DefaultPlayer end
+"""
+    get_prob(π::AbstractPolicy, obs)
 
-"Default player instance for all the environments"
-@interface const DEFAULT_PLAYER = DefaultPlayer()
+Get the probability distribution of actions based on policy `π` given an observation `obs`. The result is usually a [`Distribution`](https://juliastats.org/Distributions.jl/stable/types/#Distributions-1). More specificaly, for discrete actions, a [`Categorical`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Categorical) distribution must be returned.
+"""
+@interface get_prob(π::AbstractPolicy, obs)
+
+"""
+    get_prob(π::AbstractPolicy, obs, action)
+
+Only valid for environments with discrete action space.
+"""
+@interface get_prob(π::AbstractPolicy, obs, action)
+
+"""
+    get_priority(π::AbstractPolicy, experience)
+
+Usually used in offline policies.
+"""
+@interface get_priority(π::AbstractPolicy, experience)
+
+#####
+# Environment
+#####
+
+"""
+    (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action) -> nothing
+    (env::AbstractEnv)(player, action) -> nothing
+
+Super type of all reinforcement learning environments.
+"""
+@interface abstract type AbstractEnv end
+
+#####
+## Traits for Environment
+#####
+
+#####
+### DynamicStyle
+#####
+
+abstract type AbstractDynamicStyle end
+
+@interface struct Sequential <: AbstractDynamicStyle end
+@interface struct Simultaneous <: AbstractDynamicStyle end
+
+"Environment with the [`DynamicStyle`](@ref) of `SEQUENTIAL` must takes actions from different players one-by-one."
+@interface const SEQUENTIAL = Sequential()
+
+"Environment with the [`DynamicStyle`](@ref) of `SIMULTANEOUS` must take in actions from some (or all) players at one time"
+@interface const SIMULTANEOUS = Simultaneous()
+
+"""
+    DynamicStyle(env::AbstractEnv) = SEQUENTIAL
+
+Determine whether the players can play simultaneous or not. Default value is [`SEQUENTIAL`](@ref)
+"""
+@interface DynamicStyle(env::AbstractEnv) = SEQUENTIAL
+
+@interface (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action)
+@interface (env::AbstractEnv)(player, action)
+
+#####
+### ChanceStyle
+#####
+
+abstract type AbstractChanceStyle end
+
+@interface struct Deterministic <: AbstractChanceStyle end
+@interface struct Stochastic <: AbstractChanceStyle end
+
+"Observations are solely determined by action"
+@interface const DETERMINISTIC = Deterministic()
+
+"Observations are stochastic given by the same action"
+@interface const STOCHASTIC = Stochastic()
+
+"Either [`DETERMINISTIC`](@ref) or [`STOCHASTIC`](@ref)."
+@interface ChanceStyle(env::AbstractEnv)
+
+#####
+### InformationStyle
+#####
+
+abstract type AbstractInformationStyle end
+
+@interface struct PerfectInformation <: AbstractInformationStyle end
+@interface struct ImperfectInformation <: AbstractInformationStyle end
+
+"All players observe the same state"
+@interface const PERFECT_INFORMATION = PerfectInformation()
+
+"The inner state of some players' observations may be different"
+@interface const IMPERFECT_INFORMATION = ImperfectInformation()
+
+@interface InformationStyle(env::AbstractEnv)
+
+#####
+### RewardStyle
+#####
+
+abstract type AbstractRewardStyle end
+
+@interface struct ZeroSum <: AbstractRewardStyle end
+@interface struct ConstantSum <: AbstractRewardStyle end
+@interface struct GeneralSum <: AbstractRewardStyle end
+@interface struct IdenticalReward <: AbstractRewardStyle end
+
+"Rewards of all players sum to 0"
+@interface const ZERO_SUM = ZeroSum()
+
+"Rewards of all players sum to a constant"
+@interface const CONSTANT_SUM = ConstantSum()
+
+"Total rewards of all players may be different in each step"
+@interface const GENERAL_SUM = GeneralSum()
+
+"Every player gets the same reward"
+@interface const IDENTICAL_REWARD = IdenticalReward()
+
+@interface RewardStyle(env::AbstractEnv)
+
+#####
+### ActionStyle
+#####
 
 abstract type AbstractActionStyle end
 @interface struct FullActionSet <: AbstractActionStyle end
@@ -92,213 +178,137 @@ abstract type AbstractActionStyle end
 @interface const MINIMAL_ACTION_SET = MinimalActionSet()
 
 """
-    ActionStyle(x)
+    ActionStyle(obs)
 
 Specify whether the observation contains a full action set or a minimal action set.
 By default the [`MINIMAL_ACTION_SET`](@ref) is returned.
 """
-@interface ActionStyle(x) = MINIMAL_ACTION_SET
-
-ActionStyle(::NamedTuple{(:reward, :terminal, :state, :legal_actions)}) = FULL_ACTION_SET
-ActionStyle(::NamedTuple{(:reward, :terminal, :state, :legal_actions_mask)}) =
-    FULL_ACTION_SET
-ActionStyle(
-    ::NamedTuple{(:reward, :terminal, :state, :legal_actions, :legal_actions_mask)},
-) = FULL_ACTION_SET
-
+@interface ActionStyle(obs) = MINIMAL_ACTION_SET
 
 #####
-# Agent
+## general
 #####
 
 """
-    (agent::AbstractAgent)(obs) = agent(PRE_ACT_STAGE, obs) -> action
-    (agent::AbstractAgent)(stage::AbstractStage, obs)
-
-An agent is a functional object which takes in an observation and returns an action.
-In different stages, the behavior may be different.
+    get_action_space(env::AbstractEnv) -> AbstractSpace
 """
-@interface abstract type AbstractAgent end
+@interface get_action_space(env::AbstractEnv) = env.action_space
 
-@interface (agent::AbstractAgent)(obs) = agent(PRE_ACT_STAGE, obs)
-@interface (agent::AbstractAgent)(stage::AbstractStage, obs)
+"""
+    get_observation_space(env::AbstractEnv) -> AbstractSpace
+"""
+@interface get_observation_space(env::AbstractEnv) = env.observation_space
 
-"return [`DEFAULT_PLAYER`](@ref) by default"
-@interface get_role(::AbstractAgent) = DEFAULT_PLAYER
+"Return [`DEFAULT_PLAYER`](@ref) by default"
+@interface get_current_player(env::AbstractEnv) = DEFAULT_PLAYER
+
+"""
+    get_current_player_id(env::AbstractEnv) -> Int
+
+Get the index of current player. Result should be an Int and starts from 1.
+Usually used in multi-agent environments.
+"""
+@interface get_current_player_id(env::AbstractEnv)
+
+"""
+    get_num_players(env::AbstractEnv) -> Int
+"""
+@interface get_num_players(env::AbstractEnv) = 1
+
+"Show the environment in a user-friendly manner"
+@interface render(env::AbstractEnv)
+
+"Reset the internal state of an environment"
+@interface reset!(env::AbstractEnv)
+
+@interface Random.seed!(env::AbstractEnv, seed)
+
+@interface Base.copy(env::AbstractEnv)
+
+"Get all actions in each ply"
+@interface get_history(env::AbstractEnv)
 
 #####
-# Approximator
-#####
-
-abstract type AbstractApproximatorStyle end
-
-@interface struct VApproximator <: AbstractApproximatorStyle end
-
-"""
-For `V_APPROXIMATOR`, we assume that `(V::AbstractApproximator)(s)` is implemented.
-"""
-@interface const V_APPROXIMATOR = VApproximator()
-
-@interface struct QApproximator <: AbstractApproximatorStyle end
-
-"""
-For `Q_APPROXIMATOR`, we assume that the following methods are implemented:
-
-- `(Q::AbstractApproximator)(s, a)`, estimate the Q value.
-- `(Q::AbstractApproximator)(s)`, estimate the Q value among all possible actions.
-"""
-@interface const Q_APPROXIMATOR = QApproximator()
-
-@interface struct HybridApproximator <: AbstractApproximatorStyle end
-
-"""
-For `HYBRID_APPROXIMATOR`, the following methods are assumed to be implemented:
-- `(app::AbstractApproximator)(s, ::Val{:Q})`, estimate the action values of state `s`.
-- `(app::AbstractApproximator)(s, ::Val{:V})`, estimate the state values.
-- `(app::AbstractApproximator)(s, a)`, estimate state-action values.
-"""
-@interface const HYBRID_APPROXIMATOR = HybridApproximator()
-
-"""
-    (app::AbstractApproximator)(obs) = app(get_state(obs))
-
-An approximator is a functional object for value estimation.
-It serves as a black box to provides an abstraction over different 
-kinds of approximate methods (for example DNN provided by Flux or Knet).
-"""
-@interface abstract type AbstractApproximator end
-@interface (app::AbstractApproximator)(obs) = app(get_state(obs))
-
-"""
-    batch_estimate(app::AbstractApproximator, states)
-
-The `states` is assume to be a batch of states
-"""
-@interface batch_estimate(app::AbstractApproximator, states)
-
-"""
-    Base.copyto!(dest::AbstractApproximator, src::AbstractApproximator)
-
-Copy the internal params from `src` approximator to `dest` approximator
-"""
-@interface Base.copyto!(dest::AbstractApproximator, src::AbstractApproximator)
-
-"""
-    update!(a::AbstractApproximator, correction)
-
-Usually the `correction` is the gradient of inner parameters.
-"""
-@interface update!(a::AbstractApproximator, correction)
-
-"""
-    ApproximatorStyle(x::AbstractApproximator)
-
-Detect which kind of approximator it is
-"""
-@interface ApproximatorStyle(x::AbstractApproximator)
-
-#####
-# Learner
+## Observation
 #####
 
 """
-    (learner::AbstractLearner)(obs)
+    observe(env::AbstractEnv) = observe(env, get_current_player(env))
+    observe(::AbstractEnv, player)
 
-A learner is usually a wrapper around [`AbstractApproximator`](@ref)s.
-It defines the expected inputs and how to update inner approximators.
-From the concept level, it assumes that the necessary training data is 
-already cooked (usually by [`AbstractPolicy`](@ref) with the [`extract_experience`](@ref) method).
+Get an observation of the `env` from the perspective of an `player`.
+
+!!! note
+    This is a very deliberate decision to adopt the duck-typing here
+    to describe an observation from an environment.
+    By default, we assume an observation is a NamedTuple,
+    which is the most common case.
+    But of course it can be of any type, as long as it implemented 
+    the necessay methods described in this section.
 """
-@interface abstract type AbstractLearner end
-@interface (learner::AbstractLearner)(obs)
+@interface observe(env::AbstractEnv) = observe(env, get_current_player(env))
+@interface observe(::AbstractEnv, player)
 
 """
-    update!(learner::AbstractLearner, experience)
+    get_legal_actions_mask(obs) -> Bool[]
+
+Only valid for observations of [`FULL_ACTION_SET`](@ref).
 """
-@interface update!(learner::AbstractLearner, experience)
+@interface get_legal_actions_mask(obs) = obs.legal_actions_mask
 
 """
-    get_priority(p::AbstractLearner, experience)
+    get_legal_actions(obs)
+
+Only valid for observations of [`FULL_ACTION_SET`](@ref).
 """
-@interface get_priority(p::AbstractLearner, experience)
+@interface get_legal_actions(obs) = findall(get_legal_actions_mask(obs))
+
+get_legal_actions(
+    obs::NamedTuple{(:reward, :terminal, :state, :legal_actions, :legal_actions_mask)},
+) = obs.legal_actions
+get_legal_actions(obs::NamedTuple{(:reward, :terminal, :state, :legal_actions)}) =
+    obs.legal_actions
+
+"""
+    get_terminal(obs) -> bool
+"""
+@interface get_terminal(obs) = obs.terminal
+
+"""
+    get_reward(obs) -> Number
+"""
+@interface get_reward(obs) = obs.reward
+
+"""
+    get_state(obs) -> Array
+"""
+@interface get_state(obs) = obs.state
+
+"By default [`INVALID_ACTION`](@ref) is returned"
+@interface get_invalid_action(obs) = INVALID_ACTION
 
 #####
-# Explorer
+## Space
 #####
 
 """
-    (p::AbstractExplorer)(x)
-    (p::AbstractExplorer)(x, mask)
+Describe the span of observations and actions.
+Usually the following methods are implemented:
 
-Define how to select an action based on action values.
+- `Base.length`
+- `Base.in`
+- `Random.rand`
+- `Base.eltype`
 """
-@interface abstract type AbstractExplorer end
-@interface (p::AbstractExplorer)(x)
-@interface (p::AbstractExplorer)(x, mask)
+@interface abstract type AbstractSpace end
 
-"Reset the internal state of an explorer `p`"
-@interface reset!(p::AbstractExplorer)
+@interface Base.length(::AbstractSpace)
+@interface Base.in(x, s::AbstractSpace)
+@interface Random.rand(rng::AbstractRNG, s::AbstractSpace)
+@interface Base.eltype(s::AbstractSpace)
 
-"The internal state is also copied"
-@interface Base.copy(p::AbstractExplorer)
+# TODO: move to RLCore
 
-"""
-    get_prob(p::AbstractExplorer, x) -> AbstractDistribution
-
-Get the action distribution given action values
-"""
-@interface get_prob(p::AbstractExplorer, x)
-
-"""
-    get_prob(p::AbstractExplorer, x, mask)
-
-Similart to `get_prob(p::AbstractExplorer, x)`, but here only the `mask`ed elements are considered.
-"""
-@interface get_prob(p::AbstractExplorer, x, mask)
-
-#####
-# Policy
-#####
-
-"""
-    (p::AbstractPolicy)(obs) = p(obs, ActionStyle(obs)) -> action
-
-Similar to [`AbstractAgent`](@ref), a policy is aslo a functional object
-which defines how to generate action(s) given an observation of the environment.
-However, in the concept level, a policy is more lower and usually it doesn't need
-to care about how/when to interact with an environment.
-"""
-@interface abstract type AbstractPolicy end
-@interface (p::AbstractPolicy)(obs) = p(obs, ActionStyle(obs))
-
-"""
-    update!(p::AbstractPolicy, experience)
-
-Update the policy `p` with experience
-"""
-@interface update!(p::AbstractPolicy, experience)
-
-"""
-    get_prob(p::AbstractPolicy, obs) = get_prob(p, obs, ActionStyle(obs))
-    get_prob(p::AbstractPolicy, obs, ::AbstractActionStyle)
-Get the probability distribution of actions from the policy `p` given an observation `obs`
-"""
-@interface get_prob(p::AbstractPolicy, obs) = get_prob(p, obs, ActionStyle(obs))
-@interface get_prob(p::AbstractPolicy, obs, ::AbstractActionStyle)
-
-"""
-    get_prob(p::AbstractPolicy, obs, a) = get_prob(p, obs, ActionStyle(obs), a)
-
-Get the probability of to take action `a` from the policy `p` given an observation `obs`
-"""
-@interface get_prob(p::AbstractPolicy, obs, a) = get_prob(p, obs, ActionStyle(obs), a)
-
-"""
-    get_priority(p::AbstractPolicy, experience)
-
-Calculate the priority of the `experience` to policy `p`
-"""
-@interface get_priority(p::AbstractPolicy, experience)
 
 #####
 # Trajectory
@@ -452,144 +462,211 @@ Preprocess an observation and return a new observation.
 @interface abstract type AbstractPreprocessor end
 
 #####
-# Environment
+# general
 #####
 
 """
-    (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action) -> nothing
-    (env::AbstractEnv)(player, action) -> nothing
+The default value of invalid action for all the environments.
+However, one can still specify the value for a specific environment
+or observation.
 
-Super type of all reinforcement learning environments.
-An environments is a functional object which takes in an action and returns `nothing`.
-
-!!! note
-    So why don't we adopt the `step!` method like OpenAI Gym here?
-    The reason is that the async manner will simplify a lot of things here.
+# See also: [`get_invalid_action`](@ref)
 """
-@interface abstract type AbstractEnv end
+@interface const INVALID_ACTION = 0
 
-abstract type AbstractDynamicStyle end
+struct DefaultPlayer end
 
-@interface struct Sequential <: AbstractDynamicStyle end
-
-"Environment with the [`DynamicStyle`](@ref) of `SEQUENTIAL` must takes actions from different players one-by-one."
-@interface const SEQUENTIAL = Sequential()
-@interface struct Simultaneous <: AbstractDynamicStyle end
-
-"Environment with the [`DynamicStyle`](@ref) of `SIMULTANEOUS` must take in actions from some (or all) players at one time"
-@interface const SIMULTANEOUS = Simultaneous()
+"Default player instance for all the environments"
+@interface const DEFAULT_PLAYER = DefaultPlayer()
 
 """
-    DynamicStyle(x::AbstractEnv) = SEQUENTIAL
+In the simplest case, we just need to run `env |> observe |> agent |> env` repeatly. But usually we would also like to control when/how to update the agent. So we defined the following stages for the help:
 
-Determine whether the players can play simultaneous or not. Default value is [`SEQUENTIAL`](@ref)
+- `PRE_EXPERIMENT_STAGE`
+- `PRE_EPISODE_STAGE`
+- `PRE_ACT_STAGE`
+- `POST_ACT_STAGE`
+- `POST_EPISODE_STAGE`
+- `POST_EXPERIMENT_STAGE`
+
+```
+                      +-----------------------------------------------------------+                      
+                      |Episode                                                    |                      
+                      |                                                           |                      
+PRE_EXPERIMENT_STAGE  |            PRE_ACT_STAGE    POST_ACT_STAGE                | POST_EXPERIMENT_STAGE
+         |            |                  |                |                       |          |           
+         v            |        +-----+   v   +-------+    v   +-----+             |          v           
+         --------------------->+ env +------>+ agent +------->+ env +---> ... ------->......             
+                      |  ^     +-----+  obs  +-------+ action +-----+          ^  |                      
+                      |  |                                                     |  |                      
+                      |  +--PRE_EPISODE_STAGE            POST_EPISODE_STAGE----+  |                      
+                      |                                                           |                      
+                      |                                                           |                      
+                      +-----------------------------------------------------------+                      
+```
 """
-@interface DynamicStyle(x::AbstractEnv) = SEQUENTIAL
+@interface abstract type AbstractStage end
 
-@interface (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action)
-@interface (env::AbstractEnv)(player, action)
+@interface struct PreExperimentStage <: AbstractStage end
+@interface struct PostExperimentStage <: AbstractStage end
+@interface struct PreEpisodeStage <: AbstractStage end
+@interface struct PostEpisodeStage <: AbstractStage end
+@interface struct PreActStage <: AbstractStage end
+@interface struct PostActStage <: AbstractStage end
 
-"""
-    get_action_space(env::AbstractEnv) -> AbstractSpace
-"""
-@interface get_action_space(env::AbstractEnv) = env.action_space
-
-"""
-    get_observation_space(env::AbstractEnv) -> AbstractSpace
-"""
-@interface get_observation_space(env::AbstractEnv) = env.observation_space
-
-"Return [`DEFAULT_PLAYER`](@ref) by default"
-@interface get_current_player(env::AbstractEnv) = DEFAULT_PLAYER
-
-"""
-    get_num_players(env::AbstractEnv) -> Int
-"""
-@interface get_num_players(env::AbstractEnv) = 1
-
-"Show the environment in a user-friendly manner"
-@interface render(::AbstractEnv)
-
-"Reset the internal state of an environment"
-@interface reset!(::AbstractEnv)
-
-@interface Random.seed!(::AbstractEnv, seed)
+@interface const PRE_EXPERIMENT_STAGE = PreExperimentStage()
+@interface const POST_EXPERIMENT_STAGE = PostExperimentStage()
+@interface const PRE_EPISODE_STAGE = PreEpisodeStage()
+@interface const POST_EPISODE_STAGE = PostEpisodeStage()
+@interface const PRE_ACT_STAGE = PreActStage()
+@interface const POST_ACT_STAGE = PostActStage()
 
 #####
-# Observation
+# Agent
 #####
 
 """
-    observe(env::AbstractEnv) = observe(env, get_current_player(env))
-    observe(::AbstractEnv, player)
+    (agent::AbstractAgent)(obs) = agent(PRE_ACT_STAGE, obs) -> action
+    (agent::AbstractAgent)(stage::AbstractStage, obs)
 
-Get an observation of the `env` from the perspective of an `player`.
+An agent is a functional object which takes in an observation and returns an action.
+In different stages, the behavior may be different.
+"""
+@interface abstract type AbstractAgent end
 
-!!! note
-    This is a very deliberate decision to adopt the duck-typing here
-    to describe an observation from an environment.
-    By default, we assume an observation is a NamedTuple,
-    which is the most common case.
-    But of course it can be of any type, as long as it implemented 
-    the necessay methods described in this section.
-"""
-@interface observe(env::AbstractEnv) = observe(env, get_current_player(env))
-@interface observe(::AbstractEnv, player)
+@interface (agent::AbstractAgent)(obs) = agent(PRE_ACT_STAGE, obs)
+@interface (agent::AbstractAgent)(stage::AbstractStage, obs)
 
-"""
-    get_legal_actions_mask(x) -> Bool[]
-
-Only valid for observations of [`FULL_ACTION_SET`](@ref).
-"""
-@interface get_legal_actions_mask(x) = x.legal_actions_mask
-
-"""
-    get_legal_actions(x)
-
-Only valid for observations of [`FULL_ACTION_SET`](@ref).
-"""
-@interface get_legal_actions(x) = findall(get_legal_actions_mask(x))
-
-get_legal_actions(
-    x::NamedTuple{(:reward, :terminal, :state, :legal_actions, :legal_actions_mask)},
-) = x.legal_actions
-get_legal_actions(x::NamedTuple{(:reward, :terminal, :state, :legal_actions)}) =
-    x.legal_actions
-
-"""
-    get_terminal(x) -> bool
-"""
-@interface get_terminal(x) = x.terminal
-
-"""
-    get_reward(x) -> Number
-"""
-@interface get_reward(x) = x.reward
-
-"""
-    get_state(x) -> Array
-"""
-@interface get_state(x) = x.state
-
-"By default [`INVALID_ACTION`](@ref) is returned"
-@interface get_invalid_action(x) = INVALID_ACTION
+"return [`DEFAULT_PLAYER`](@ref) by default"
+@interface get_role(::AbstractAgent) = DEFAULT_PLAYER
 
 #####
-# Space
+# Approximator
+#####
+
+abstract type AbstractApproximatorStyle end
+
+@interface struct VApproximator <: AbstractApproximatorStyle end
+
+"""
+For `V_APPROXIMATOR`, we assume that `(V::AbstractApproximator)(s)` is implemented.
+"""
+@interface const V_APPROXIMATOR = VApproximator()
+
+@interface struct QApproximator <: AbstractApproximatorStyle end
+
+"""
+For `Q_APPROXIMATOR`, we assume that the following methods are implemented:
+
+- `(Q::AbstractApproximator)(s, a)`, estimate the Q value.
+- `(Q::AbstractApproximator)(s)`, estimate the Q value among all possible actions.
+"""
+@interface const Q_APPROXIMATOR = QApproximator()
+
+@interface struct HybridApproximator <: AbstractApproximatorStyle end
+
+"""
+For `HYBRID_APPROXIMATOR`, the following methods are assumed to be implemented:
+- `(app::AbstractApproximator)(s, ::Val{:Q})`, estimate the action values of state `s`.
+- `(app::AbstractApproximator)(s, ::Val{:V})`, estimate the state values.
+- `(app::AbstractApproximator)(s, a)`, estimate state-action values.
+"""
+@interface const HYBRID_APPROXIMATOR = HybridApproximator()
+
+"""
+    (app::AbstractApproximator)(obs) = app(get_state(obs))
+
+An approximator is a functional object for value estimation.
+It serves as a black box to provides an abstraction over different 
+kinds of approximate methods (for example DNN provided by Flux or Knet).
+"""
+@interface abstract type AbstractApproximator end
+@interface (app::AbstractApproximator)(obs) = app(get_state(obs))
+
+"""
+    batch_estimate(app::AbstractApproximator, states)
+
+The `states` is assume to be a batch of states
+"""
+@interface batch_estimate(app::AbstractApproximator, states)
+
+"""
+    Base.copyto!(dest::AbstractApproximator, src::AbstractApproximator)
+
+Copy the internal params from `src` approximator to `dest` approximator
+"""
+@interface Base.copyto!(dest::AbstractApproximator, src::AbstractApproximator)
+
+"""
+    update!(a::AbstractApproximator, correction)
+
+Usually the `correction` is the gradient of inner parameters.
+"""
+@interface update!(a::AbstractApproximator, correction)
+
+"""
+    ApproximatorStyle(x::AbstractApproximator)
+
+Detect which kind of approximator it is
+"""
+@interface ApproximatorStyle(x::AbstractApproximator)
+
+#####
+# Learner
 #####
 
 """
-Describe the span of observations and actions.
-Usually the following methods are implemented:
+    (learner::AbstractLearner)(obs)
 
-- `Base.length`
-- `Base.in`
-- `Random.rand`
-- `Base.eltype`
+A learner is usually a wrapper around [`AbstractApproximator`](@ref)s.
+It defines the expected inputs and how to update inner approximators.
+From the concept level, it assumes that the necessary training data is 
+already cooked (usually by [`AbstractPolicy`](@ref) with the [`extract_experience`](@ref) method).
 """
-@interface abstract type AbstractSpace end
+@interface abstract type AbstractLearner end
+@interface (learner::AbstractLearner)(obs)
 
-@interface Base.length(::AbstractSpace)
-@interface Base.in(x, s::AbstractSpace)
-@interface Random.rand(rng::AbstractRNG, s::AbstractSpace)
-@interface Base.eltype(s::AbstractSpace)
+"""
+    update!(learner::AbstractLearner, experience)
+"""
+@interface update!(learner::AbstractLearner, experience)
+
+"""
+    get_priority(p::AbstractLearner, experience)
+"""
+@interface get_priority(p::AbstractLearner, experience)
+
+#####
+# Explorer
+#####
+
+"""
+    (p::AbstractExplorer)(x)
+    (p::AbstractExplorer)(x, mask)
+
+Define how to select an action based on action values.
+"""
+@interface abstract type AbstractExplorer end
+@interface (p::AbstractExplorer)(x)
+@interface (p::AbstractExplorer)(x, mask)
+
+"Reset the internal state of an explorer `p`"
+@interface reset!(p::AbstractExplorer)
+
+"The internal state is also copied"
+@interface Base.copy(p::AbstractExplorer)
+
+"""
+    get_prob(p::AbstractExplorer, x) -> AbstractDistribution
+
+Get the action distribution given action values
+"""
+@interface get_prob(p::AbstractExplorer, x)
+
+"""
+    get_prob(p::AbstractExplorer, x, mask)
+
+Similart to `get_prob(p::AbstractExplorer, x)`, but here only the `mask`ed elements are considered.
+"""
+@interface get_prob(p::AbstractExplorer, x, mask)
+

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -38,7 +38,7 @@ Update the policy `π` with online/offline experience.
 """
     get_prob(π::AbstractPolicy, obs)
 
-Get the probability distribution of actions based on policy `π` given an observation `obs`. The result is usually a [`Distribution`](https://juliastats.org/Distributions.jl/stable/types/#Distributions-1). More specificaly, for discrete actions, a [`Categorical`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Categorical) distribution must be returned.
+Get the probability distribution of actions based on policy `π` given an observation `obs`. 
 """
 @interface get_prob(π::AbstractPolicy, obs)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,18 +3,13 @@
 provides some common constants, traits, abstractions and interfaces in developing reinforcement learning algorithms in 
 Julia. From the concept level, they can be organized in the following parts:
 
-- [General](@ref)
-- [Agent](@ref)
-  - [Policy](@ref)
-    - [Learner](@ref)
-      - [Approximator](@ref)
-    - [Explorer](@ref)
+- [Policy](@ref)
 - [EnvironmentModel](@ref)
 - [Environment](@ref)
-  - [Preprocessor](@ref)
-  - [Observation](@ref)
-  - [Trajectory](@ref)
-  - [Space](@ref)
+  - [Traits for Environment](@ref)
+  - [Observation of Environment](@ref)
+  - [Observation Space and Action Space](@ref)
+- [ EnvironmentModel](@ref)
 
 """ RLBase
 
@@ -73,8 +68,12 @@ Super type of all reinforcement learning environments.
 """
 @interface abstract type AbstractEnv end
 
+@interface (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action)
+@interface (env::AbstractEnv)(player, action)
+
 #####
 ## Traits for Environment
+## mostly borrowed from https://github.com/deepmind/open_spiel/blob/master/open_spiel/spiel.h
 #####
 
 #####
@@ -98,9 +97,6 @@ abstract type AbstractDynamicStyle end
 Determine whether the players can play simultaneous or not. Default value is [`SEQUENTIAL`](@ref)
 """
 @interface DynamicStyle(env::AbstractEnv) = SEQUENTIAL
-
-@interface (env::AbstractEnv)(action) = env(DEFAULT_PLAYER, action)
-@interface (env::AbstractEnv)(player, action)
 
 #####
 ### ChanceStyle
@@ -143,10 +139,25 @@ abstract type AbstractInformationStyle end
 
 abstract type AbstractRewardStyle end
 
-@interface struct ZeroSum <: AbstractRewardStyle end
-@interface struct ConstantSum <: AbstractRewardStyle end
-@interface struct GeneralSum <: AbstractRewardStyle end
-@interface struct IdenticalReward <: AbstractRewardStyle end
+@interface struct StepReward <: AbstractRewardStyle end
+@interface struct TerminalReward <: AbstractRewardStyle end
+
+"We can get reward after each step"
+@interface const STEP_REWARD = StepReward()
+
+"Only get reward at the end of environment"
+@interface const TERMINAL_REWARD = TerminalReward()
+
+#####
+### UtilityStyle
+#####
+
+abstract type AbstractUtilityStyle end
+
+@interface struct ZeroSum <: AbstractUtilityStyle end
+@interface struct ConstantSum <: AbstractUtilityStyle end
+@interface struct GeneralSum <: AbstractUtilityStyle end
+@interface struct IdenticalUtility <: AbstractUtilityStyle end
 
 "Rewards of all players sum to 0"
 @interface const ZERO_SUM = ZeroSum()
@@ -158,9 +169,9 @@ abstract type AbstractRewardStyle end
 @interface const GENERAL_SUM = GeneralSum()
 
 "Every player gets the same reward"
-@interface const IDENTICAL_REWARD = IdenticalReward()
+@interface const IDENTICAL_REWARD = IdenticalUtility()
 
-@interface RewardStyle(env::AbstractEnv)
+@interface UtilityStyle(env::AbstractEnv)
 
 #####
 ### ActionStyle
@@ -203,12 +214,12 @@ By default the [`MINIMAL_ACTION_SET`](@ref) is returned.
 @interface get_current_player(env::AbstractEnv) = DEFAULT_PLAYER
 
 """
-    get_current_player_id(env::AbstractEnv) -> Int
+    get_player_id(player, env::AbstractEnv) -> Int
 
 Get the index of current player. Result should be an Int and starts from 1.
 Usually used in multi-agent environments.
 """
-@interface get_current_player_id(env::AbstractEnv)
+@interface get_player_id(player, env::AbstractEnv)
 
 """
     get_num_players(env::AbstractEnv) -> Int
@@ -284,9 +295,6 @@ get_legal_actions(obs::NamedTuple{(:reward, :terminal, :state, :legal_actions)})
 """
 @interface get_state(obs) = obs.state
 
-"By default [`INVALID_ACTION`](@ref) is returned"
-@interface get_invalid_action(obs) = INVALID_ACTION
-
 #####
 ## Space
 #####
@@ -307,143 +315,13 @@ Usually the following methods are implemented:
 @interface Random.rand(rng::AbstractRNG, s::AbstractSpace)
 @interface Base.eltype(s::AbstractSpace)
 
-# TODO: move to RLCore
-
-
-#####
-# Trajectory
-#####
-
-"""
-    AbstractTrajectory{names,types} <: AbstractArray{NamedTuple{names,types},1}
-
-A trajectory is used to record some useful information
-during the interactions between agents and environments.
-
-# Parameters
-
-- `names`::`NTuple{Symbol}`, indicate what fields to be recorded.
-- `types`::`Tuple{DataType...}`, the datatypes of `names`.
-
-The length of `names` and `types` must match.
-
-Required Methods:
-
-- [`get_trace`](@ref)
-- `Base.push!(t::AbstractTrajectory, kv::Pair{Symbol})`
-- `Base.pop!(t::AbstractTrajectory, s::Symbol)`
-
-Optional Methods:
-
-- `Base.length`
-- `Base.size`
-- `Base.lastindex`
-- `Base.isempty`
-- `Base.empty!`
-- `Base.push!`
-- `Base.pop!`
-"""
-@interface abstract type AbstractTrajectory{names,types} <:
-                         AbstractArray{NamedTuple{names,types},1} end
-
-# some typical trace names
-"An alias of `(:reward, :terminal, :state, :action)`"
-@interface const RTSA = (:reward, :terminal, :state, :action)
-
-"An alias of `(:state, :action, :reward, :terminal, :next_state, :next_action)`"
-@interface const SARTSA = (:state, :action, :reward, :terminal, :next_state, :next_action)
-
-"""
-    get_trace(t::AbstractTrajectory, s::Symbol)
-"""
-@interface get_trace(t::AbstractTrajectory, s::Symbol)
-
-"""
-    get_trace(t::AbstractTrajectory, s::NTuple{N,Symbol}) where {N}
-"""
-get_trace(t::AbstractTrajectory, s::NTuple{N,Symbol}) where {N} =
-    NamedTuple{s}(get_trace(t, x) for x in s)
-
-"""
-    get_trace(t::AbstractTrajectory, s::Symbol...)
-"""
-get_trace(t::AbstractTrajectory, s::Symbol...) = get_trace(t, s)
-
-"""
-    get_trace(t::AbstractTrajectory{names}) where {names}
-"""
-get_trace(t::AbstractTrajectory{names}) where {names} =
-    NamedTuple{names}(get_trace(t, x) for x in names)
-
-@interface Base.length(t::AbstractTrajectory) = maximum(length(x) for x in get_trace(t))
-@interface Base.size(t::AbstractTrajectory) = (length(t),)
-@interface Base.lastindex(t::AbstractTrajectory) = length(t)
-@interface Base.getindex(t::AbstractTrajectory{names,types}, i::Int) where {names,types} =
-    NamedTuple{names,types}(Tuple(x[i] for x in get_trace(t)))
-
-@interface Base.isempty(t::AbstractTrajectory) = all(isempty(t) for t in get_trace(t))
-
-@interface function Base.empty!(t::AbstractTrajectory)
-    for x in get_trace(t)
-        empty!(x)
-    end
-end
-
-"""
-    Base.push!(t::AbstractTrajectory; kwargs...)
-"""
-@interface function Base.push!(t::AbstractTrajectory; kwargs...)
-    for kv in kwargs
-        push!(t, kv)
-    end
-end
-
-"""
-    Base.push!(t::AbstractTrajectory, kv::Pair{Symbol})
-"""
-@interface Base.push!(t::AbstractTrajectory, kv::Pair{Symbol})
-
-"""
-    Base.pop!(t::AbstractTrajectory{names}) where {names}
-
-`pop!` out one element of each trace in `t`
-"""
-@interface function Base.pop!(t::AbstractTrajectory{names}) where {names}
-    pop!(t, names...)
-end
-
-"""
-    Base.pop!(t::AbstractTrajectory, s::Symbol...)
-
-`pop!` out one element of the traces specified in `s`
-"""
-@interface function Base.pop!(t::AbstractTrajectory, s::Symbol...)
-    NamedTuple{s}(pop!(t, x) for x in s)
-end
-
-"""
-    Base.pop!(t::AbstractTrajectory, s::Symbol)
-
-`pop!` out one element of the trace `s` in `t`
-"""
-@interface Base.pop!(t::AbstractTrajectory, s::Symbol)
-
-"""
-    extract_experience(trajectory::AbstractTrajectory, learner::AbstractLearner)
-
-Extract necessary data from the `trajectory` given a `learner`
-"""
-@interface extract_experience(trajectory::AbstractTrajectory, learner::AbstractLearner)
-
 #####
 # EnvironmentModel
 #####
 
 """
 Describe how to model a reinforcement learning environment.
-
 TODO: need more investigation
-
 Ref: https://bair.berkeley.edu/blog/2019/12/12/mbpo/
 - Analytic gradient computation
 - Sampling-based planning
@@ -451,222 +329,3 @@ Ref: https://bair.berkeley.edu/blog/2019/12/12/mbpo/
 - Value-equivalence prediction
 """
 @interface abstract type AbstractEnvironmentModel end
-
-#####
-# Preprocessor
-#####
-
-"""
-Preprocess an observation and return a new observation.
-"""
-@interface abstract type AbstractPreprocessor end
-
-#####
-# general
-#####
-
-"""
-The default value of invalid action for all the environments.
-However, one can still specify the value for a specific environment
-or observation.
-
-# See also: [`get_invalid_action`](@ref)
-"""
-@interface const INVALID_ACTION = 0
-
-struct DefaultPlayer end
-
-"Default player instance for all the environments"
-@interface const DEFAULT_PLAYER = DefaultPlayer()
-
-"""
-In the simplest case, we just need to run `env |> observe |> agent |> env` repeatly. But usually we would also like to control when/how to update the agent. So we defined the following stages for the help:
-
-- `PRE_EXPERIMENT_STAGE`
-- `PRE_EPISODE_STAGE`
-- `PRE_ACT_STAGE`
-- `POST_ACT_STAGE`
-- `POST_EPISODE_STAGE`
-- `POST_EXPERIMENT_STAGE`
-
-```
-                      +-----------------------------------------------------------+                      
-                      |Episode                                                    |                      
-                      |                                                           |                      
-PRE_EXPERIMENT_STAGE  |            PRE_ACT_STAGE    POST_ACT_STAGE                | POST_EXPERIMENT_STAGE
-         |            |                  |                |                       |          |           
-         v            |        +-----+   v   +-------+    v   +-----+             |          v           
-         --------------------->+ env +------>+ agent +------->+ env +---> ... ------->......             
-                      |  ^     +-----+  obs  +-------+ action +-----+          ^  |                      
-                      |  |                                                     |  |                      
-                      |  +--PRE_EPISODE_STAGE            POST_EPISODE_STAGE----+  |                      
-                      |                                                           |                      
-                      |                                                           |                      
-                      +-----------------------------------------------------------+                      
-```
-"""
-@interface abstract type AbstractStage end
-
-@interface struct PreExperimentStage <: AbstractStage end
-@interface struct PostExperimentStage <: AbstractStage end
-@interface struct PreEpisodeStage <: AbstractStage end
-@interface struct PostEpisodeStage <: AbstractStage end
-@interface struct PreActStage <: AbstractStage end
-@interface struct PostActStage <: AbstractStage end
-
-@interface const PRE_EXPERIMENT_STAGE = PreExperimentStage()
-@interface const POST_EXPERIMENT_STAGE = PostExperimentStage()
-@interface const PRE_EPISODE_STAGE = PreEpisodeStage()
-@interface const POST_EPISODE_STAGE = PostEpisodeStage()
-@interface const PRE_ACT_STAGE = PreActStage()
-@interface const POST_ACT_STAGE = PostActStage()
-
-#####
-# Agent
-#####
-
-"""
-    (agent::AbstractAgent)(obs) = agent(PRE_ACT_STAGE, obs) -> action
-    (agent::AbstractAgent)(stage::AbstractStage, obs)
-
-An agent is a functional object which takes in an observation and returns an action.
-In different stages, the behavior may be different.
-"""
-@interface abstract type AbstractAgent end
-
-@interface (agent::AbstractAgent)(obs) = agent(PRE_ACT_STAGE, obs)
-@interface (agent::AbstractAgent)(stage::AbstractStage, obs)
-
-"return [`DEFAULT_PLAYER`](@ref) by default"
-@interface get_role(::AbstractAgent) = DEFAULT_PLAYER
-
-#####
-# Approximator
-#####
-
-abstract type AbstractApproximatorStyle end
-
-@interface struct VApproximator <: AbstractApproximatorStyle end
-
-"""
-For `V_APPROXIMATOR`, we assume that `(V::AbstractApproximator)(s)` is implemented.
-"""
-@interface const V_APPROXIMATOR = VApproximator()
-
-@interface struct QApproximator <: AbstractApproximatorStyle end
-
-"""
-For `Q_APPROXIMATOR`, we assume that the following methods are implemented:
-
-- `(Q::AbstractApproximator)(s, a)`, estimate the Q value.
-- `(Q::AbstractApproximator)(s)`, estimate the Q value among all possible actions.
-"""
-@interface const Q_APPROXIMATOR = QApproximator()
-
-@interface struct HybridApproximator <: AbstractApproximatorStyle end
-
-"""
-For `HYBRID_APPROXIMATOR`, the following methods are assumed to be implemented:
-- `(app::AbstractApproximator)(s, ::Val{:Q})`, estimate the action values of state `s`.
-- `(app::AbstractApproximator)(s, ::Val{:V})`, estimate the state values.
-- `(app::AbstractApproximator)(s, a)`, estimate state-action values.
-"""
-@interface const HYBRID_APPROXIMATOR = HybridApproximator()
-
-"""
-    (app::AbstractApproximator)(obs) = app(get_state(obs))
-
-An approximator is a functional object for value estimation.
-It serves as a black box to provides an abstraction over different 
-kinds of approximate methods (for example DNN provided by Flux or Knet).
-"""
-@interface abstract type AbstractApproximator end
-@interface (app::AbstractApproximator)(obs) = app(get_state(obs))
-
-"""
-    batch_estimate(app::AbstractApproximator, states)
-
-The `states` is assume to be a batch of states
-"""
-@interface batch_estimate(app::AbstractApproximator, states)
-
-"""
-    Base.copyto!(dest::AbstractApproximator, src::AbstractApproximator)
-
-Copy the internal params from `src` approximator to `dest` approximator
-"""
-@interface Base.copyto!(dest::AbstractApproximator, src::AbstractApproximator)
-
-"""
-    update!(a::AbstractApproximator, correction)
-
-Usually the `correction` is the gradient of inner parameters.
-"""
-@interface update!(a::AbstractApproximator, correction)
-
-"""
-    ApproximatorStyle(x::AbstractApproximator)
-
-Detect which kind of approximator it is
-"""
-@interface ApproximatorStyle(x::AbstractApproximator)
-
-#####
-# Learner
-#####
-
-"""
-    (learner::AbstractLearner)(obs)
-
-A learner is usually a wrapper around [`AbstractApproximator`](@ref)s.
-It defines the expected inputs and how to update inner approximators.
-From the concept level, it assumes that the necessary training data is 
-already cooked (usually by [`AbstractPolicy`](@ref) with the [`extract_experience`](@ref) method).
-"""
-@interface abstract type AbstractLearner end
-@interface (learner::AbstractLearner)(obs)
-
-"""
-    update!(learner::AbstractLearner, experience)
-"""
-@interface update!(learner::AbstractLearner, experience)
-
-"""
-    get_priority(p::AbstractLearner, experience)
-"""
-@interface get_priority(p::AbstractLearner, experience)
-
-#####
-# Explorer
-#####
-
-"""
-    (p::AbstractExplorer)(x)
-    (p::AbstractExplorer)(x, mask)
-
-Define how to select an action based on action values.
-"""
-@interface abstract type AbstractExplorer end
-@interface (p::AbstractExplorer)(x)
-@interface (p::AbstractExplorer)(x, mask)
-
-"Reset the internal state of an explorer `p`"
-@interface reset!(p::AbstractExplorer)
-
-"The internal state is also copied"
-@interface Base.copy(p::AbstractExplorer)
-
-"""
-    get_prob(p::AbstractExplorer, x) -> AbstractDistribution
-
-Get the action distribution given action values
-"""
-@interface get_prob(p::AbstractExplorer, x)
-
-"""
-    get_prob(p::AbstractExplorer, x, mask)
-
-Similart to `get_prob(p::AbstractExplorer, x)`, but here only the `mask`ed elements are considered.
-"""
-@interface get_prob(p::AbstractExplorer, x, mask)
-

--- a/test/base.jl
+++ b/test/base.jl
@@ -1,0 +1,11 @@
+@testset "base" begin
+    env = LotteryEnv(;seed=222)
+    action_space = get_action_space(env)
+    policy = RandomPolicy(env;seed=123)
+    rewards = []
+    for _ in 1:1000
+        reset!(env)
+        run(policy, env)
+        push!(rewards, get_reward(observe(env)))
+    end
+end

--- a/test/base.jl
+++ b/test/base.jl
@@ -2,10 +2,7 @@
     env = LotteryEnv(;seed=222)
     action_space = get_action_space(env)
     policy = RandomPolicy(env;seed=123)
-    rewards = []
-    for _ in 1:1000
-        reset!(env)
-        run(policy, env)
-        push!(rewards, get_reward(observe(env)))
-    end
+    reset!(env)
+    run(policy, env)
+    @test get_terminal(observe(env))
 end

--- a/test/lottery_env.jl
+++ b/test/lottery_env.jl
@@ -1,0 +1,41 @@
+using Random
+
+#####
+# LotteryEnv
+#####
+
+"""
+    LotteryEnv()
+
+Here we use an example introduced in [Monte Carlo Tree Search: A Tutorial](https://www.informs-sim.org/wsc18papers/includes/files/021.pdf) to demenstrate how to write an environment.
+
+Assume you have \$10 in your pocket, and you are faced with the following three choices:
+
+1. buy a PowerRich lottery ticket (win \$100M w.p. 0.01; nothing otherwise);
+2. buy a MegaHaul lottery ticket (win \$1M w.p. 0.05; nothing otherwise);
+3. do not buy a lottery ticket.
+"""
+mutable struct LotteryEnv <: AbstractEnv
+    reward::Int
+    is_done::Bool
+    rng::MersenneTwister
+end
+
+LotteryEnv(;seed=nothing) = LotteryEnv(0, false, MersenneTwister(seed))
+
+RLBase.get_action_space(env::LotteryEnv) = DiscreteSpace((:PowerRich, :MegaHaul, nothing))
+
+function (env::LotteryEnv)(action::Union{Symbol,Nothing})
+    if action == :PowerRich
+        env.reward = rand(env.rng) < 0.01 ? 100_000_000 : -10
+    elseif action == :MegaHaul
+        env.reward = rand(env.rng) < 0.05 ? 1_000_000 : -10
+    else
+        env.reward = 0
+    end
+    env.is_done = true
+end
+
+RLBase.observe(env::LotteryEnv) = (reward=env.reward, terminal=env.is_done)
+
+RLBase.reset!(env::LotteryEnv) = env.is_done = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ReinforcementLearningBase
 using Test
 
+include("lottery_env.jl")
+
 @testset "ReinforcementLearningBase" begin
     include("spaces.jl")
     include("base.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Test
 
 @testset "ReinforcementLearningBase" begin
     include("spaces.jl")
+    include("base.jl")
 end


### PR DESCRIPTION
fix #39  close #38 

To avoid introducing too many unnecessary concepts in RLBase, only policy and environment related APIs are kept. Agent, learner, approximator will be moved to RLCore.

<hr>

Changes:

- Only keep **Policy** and **Environment** related APIs in RLBase.
- Add more traits to support multi-agent environments.
  - ChanceStyle
  - InformationStyle
  - RewardStyle
  - UtilityStyle
  - ActionStyle
- Add `get_player_id` and `get_history` to environments.
- Move random policy from RLCore to RLBase since it's general enough.
- Move some general preprocessor into RLBase.
- Extend `Base.run` for running simulation.