### PR TITLE
add env that terminates after max threshold time

### DIFF
--- a/src/implementations/environments.jl
+++ b/src/implementations/environments.jl
@@ -164,6 +164,9 @@ function (env::MaxTimeoutEnv)(args...; kwargs...)
     env.current_t = env.current_t + 1
 end
 
+# partial constructor to allow chaining
+MaxTimeoutEnv(max_t::Int; current_t::Int = 1) = env -> MaxTimeoutEnv(env, max_t, current_t)
+
 for f in vcat(ENV_API, MULTI_AGENT_ENV_API)
     if f != :get_terminal
         @eval $f(x::MaxTimeoutEnv, args...; kwargs...) = $f(x.env, args...; kwargs...)

--- a/src/implementations/environments.jl
+++ b/src/implementations/environments.jl
@@ -4,7 +4,8 @@ export SubjectiveEnv,
     StateOverriddenEnv,
     RewardOverriddenEnv,
     ActionTransformedEnv,
-    StateCachedEnv
+    StateCachedEnv,
+    MaxTimeoutEnv
 
 using MacroTools: @forward
 using Random
@@ -146,6 +147,30 @@ end
 
 get_reward(env::RewardOverriddenEnv, args...; kwargs...) =
     foldl(|>, env.processors; init = get_reward(env.env, args...; kwargs...))
+
+
+#####
+# MaxTimeoutEnv
+#####
+
+mutable struct MaxTimeoutEnv{E<:AbstractEnv} <: AbstractEnv
+    env::E
+    max_t::Int
+    current_t::Int
+end
+
+function (env::MaxTimeoutEnv)(args...; kwargs...)
+    env.env(args...; kwargs...)
+    env.current_t = env.current_t + 1
+end
+
+for f in vcat(ENV_API, MULTI_AGENT_ENV_API)
+    if f != :get_terminal
+        @eval $f(x::MaxTimeoutEnv, args...; kwargs...) = $f(x.env, args...; kwargs...)
+    end
+end
+
+get_terminal(env::MaxTimeoutEnv) = (env.current_t > env.max_t) || get_terminal(env.env)
 
 #####
 # ActionTransformedEnv


### PR DESCRIPTION
I have created a `MaxTimeoutEnv` wrapper for environments.

This will track the current time elapsed, `current_t` (given by the number of steps taken in the environment so far) and compares it with a maximum allowed threshold `max_t`.

An environment wrapped by `MaxTimeoutEnv` terminates (that is, `get_terminal(env)` returns `true`) if either `current_t` exceeds the maximum threshold `max_t`, or if the underlying environment terminates.