### PR TITLE
add current_t kwarg for the (full) constructor

### DIFF
--- a/src/implementations/environments.jl
+++ b/src/implementations/environments.jl
@@ -159,6 +159,8 @@ mutable struct MaxTimeoutEnv{E<:AbstractEnv} <: AbstractEnv
     current_t::Int
 end
 
+MaxTimeoutEnv(env::E, max_t::Int; current_t::Int = 1) where E<:AbstractEnv = MaxTimeoutEnv(E, max_t, current_t)
+
 function (env::MaxTimeoutEnv)(args...; kwargs...)
     env.env(args...; kwargs...)
     env.current_t = env.current_t + 1


### PR DESCRIPTION
We have previously added an optional keyword argument for `current_t` in the partial constructor for `MaxTimeoutEnv`.

It just occurred to me that for consistency, we should also add the same for the normal (full) constructor.

Adding that in this PR.