### PR TITLE
Fix bug in MaxTimeoutEnv

### DIFF
--- a/src/implementations/environments.jl
+++ b/src/implementations/environments.jl
@@ -160,7 +160,7 @@ mutable struct MaxTimeoutEnv{E<:AbstractEnv} <: AbstractEnv
 end
 
 MaxTimeoutEnv(env::E, max_t::Int; current_t::Int = 1) where {E<:AbstractEnv} =
-    MaxTimeoutEnv(E, max_t, current_t)
+    MaxTimeoutEnv(env, max_t, current_t)
 
 function (env::MaxTimeoutEnv)(args...; kwargs...)
     env.env(args...; kwargs...)


### PR DESCRIPTION
I found a bug in `MaxTimeoutEnv` constructor.
Fixing it in this PR.